### PR TITLE
docs: Update README with AUR Installation Instructions for Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gj"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Efe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Efe
+Copyright (c) 2025 Efe Karasakal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Note:_ It will probably work on other linux distributions too. But I haven't pe
 ```bash
 git clone https://github.com/efekrskl/gj && cd gj
 cargo build --release
-cp /target/release/gj /usr/bin/
+cp target/release/gj /usr/bin/
 ```
 
 ### Arch Linux (from AUR)

--- a/README.md
+++ b/README.md
@@ -5,12 +5,31 @@ Type your thoughts into the terminal — they get logged to Notion, one page per
 
 <img width="1293" alt="image" src="https://github.com/user-attachments/assets/240aec31-1cc4-4e66-9b4c-3ca75429efa3" />
 
-
 ## Install
+
+### MacOS (homebrew)
 
 ```bash
 brew tap efekrskl/gj
 brew install gj
+```
+
+### Arch Linux (build from source)
+
+_Note:_ It will probably work on other linux distributions too. But I haven't personally tested it.
+
+```bash
+git clone https://github.com/efekrskl/gj && cd gj
+cargo build --release
+cp /target/release/gj /usr/bin/
+```
+
+### Arch Linux (from AUR)
+
+You can install AUR packages either via `paru` or `yay`. The procedure is the same for both.
+
+```bash
+paru -S gj-git
 ```
 
 ## Usage


### PR DESCRIPTION
**Description**
This pull request informs the repository owner about the newly added [AUR package](https://aur.archlinux.org/packages/gj-git) for the project, making it easier for Arch Linux users to install via AUR (Arch User Repository). Also added a LICENSE file.

**Short Summary**

This update provides two installation methods for Arch Linux users:

1. A method for compiling from source using simple commands.

2. An easier method for installation via AUR. (which benefits users without experience in compiling from source)

**Screenshot**

Screenshot showing that it works in Linux:

![2025-04-20-gj_git](https://github.com/user-attachments/assets/b9b18107-81e7-4854-a93e-c99383fe911a)
